### PR TITLE
hud: hide hud when debug menu is open

### DIFF
--- a/src/main/java/fin/starhud/hud/HUDComponent.java
+++ b/src/main/java/fin/starhud/hud/HUDComponent.java
@@ -6,6 +6,7 @@ import fin.starhud.config.GroupedHUDSettings;
 import fin.starhud.config.HUDList;
 import fin.starhud.hud.implementation.*;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.MinecraftClient;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -164,10 +165,12 @@ public class HUDComponent {
             lastCollect = now;
         }
 
-        for (AbstractHUD hud : renderedHUDs) {
-            if (!hud.render(context)) {
-                LOGGER.warn("{} is collected but still failed! Removing from rendered hud.", hud.getName());
-                invalidHUDs.add(hud);
+        if (!MinecraftClient.getInstance().getDebugHud().shouldShowDebugHud()) {
+            for (AbstractHUD hud : renderedHUDs) {
+                if (!hud.render(context)) {
+                    LOGGER.warn("{} is collected but still failed! Removing from rendered hud.", hud.getName());
+                    invalidHUDs.add(hud);
+                }
             }
         }
 


### PR DESCRIPTION
I've played around a bit with StarHUD, but one thing that annoys me is that it’s still visible even when the debug menu (F3) is open. Maybe there could be an option to enable this feature in the future, but for now, I would just hide the HUD when the debug menu is open.

Changes have been tested in-game.

**Changes**
- `HudComponent.java` skip rendering hud when debug menu is open