### PR TITLE
fix: complete 26.1 neoforge port

### DIFF
--- a/fabric/src/main/java/fin/starhud/init/EventInit.java
+++ b/fabric/src/main/java/fin/starhud/init/EventInit.java
@@ -46,7 +46,7 @@ public class EventInit {
 
     public static void onOpenEditHUDKeyPressed(Minecraft client) {
         while (Main.openEditHUDKey.consumeClick()) {
-            client.setScreenAndShow(new EditHUDScreen(Component.nullToEmpty("Edit HUD"), client.screen));
+            client.setScreen(new EditHUDScreen(Component.nullToEmpty("Edit HUD"), client.screen));
         }
     }
 

--- a/neoforge/src/main/java/fin/starhud/ForgeMain.java
+++ b/neoforge/src/main/java/fin/starhud/ForgeMain.java
@@ -16,8 +16,7 @@ public class ForgeMain {
 
         ConfigInit.init();
         KeybindInit.init();
-        EventInit.init();
-        HUDComponent.getInstance().init();
+        EventInit.init(eventBus);
 
         ModListIntegration.registerModScreen(container);
 

--- a/neoforge/src/main/java/fin/starhud/ForgeMain.java
+++ b/neoforge/src/main/java/fin/starhud/ForgeMain.java
@@ -1,5 +1,6 @@
 package fin.starhud;
 
+import fin.starhud.hud.HUDComponent;
 import fin.starhud.init.ConfigInit;
 import fin.starhud.init.EventInit;
 import fin.starhud.init.KeybindInit;
@@ -16,6 +17,7 @@ public class ForgeMain {
         ConfigInit.init();
         KeybindInit.init();
         EventInit.init();
+        HUDComponent.getInstance().init();
 
         ModListIntegration.registerModScreen(container);
 

--- a/neoforge/src/main/java/fin/starhud/init/EventInit.java
+++ b/neoforge/src/main/java/fin/starhud/init/EventInit.java
@@ -11,6 +11,8 @@ import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.network.chat.Component;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RenderGuiEvent;
@@ -24,7 +26,7 @@ public class EventInit {
 
     private static final GeneralSettings.InGameHUDSettings SETTINGS = Main.settings.generalSettings.inGameSettings;
 
-    public static void init() {
+    public static void init(IEventBus eventBus) {
 
         // register AttackTracker events, for combo and reach.
         NeoForge.EVENT_BUS.addListener(EventInit::onAttack);
@@ -40,7 +42,7 @@ public class EventInit {
         NeoForge.EVENT_BUS.addListener(EventInit::onHUDRender);
 
         // extra on login to wait until Minecraft.instace() is valid
-        NeoForge.EVENT_BUS.addListener(EventInit::onLogin);
+        eventBus.addListener(EventInit::onLogin);
     }
 
     public static void onClientStopping(GameShuttingDownEvent event) {
@@ -82,7 +84,7 @@ public class EventInit {
         AttackTracker.onEndTick(Minecraft.getInstance());
     }
 
-    public static void onLogin(ClientPlayerNetworkEvent.LoggingIn event) {
+    public static void onLogin(FMLLoadCompleteEvent event) {
         HUDComponent.getInstance().init();
     }
 }

--- a/neoforge/src/main/java/fin/starhud/init/EventInit.java
+++ b/neoforge/src/main/java/fin/starhud/init/EventInit.java
@@ -54,7 +54,7 @@ public class EventInit {
         Minecraft client = Minecraft.getInstance();
 
         while (Main.openEditHUDKey.consumeClick()) {
-            client.setScreenAndShow(new EditHUDScreen(Component.nullToEmpty("Edit HUD"), client.screen));
+            client.setScreen(new EditHUDScreen(Component.nullToEmpty("Edit HUD"), client.screen));
         }
     }
 


### PR DESCRIPTION
## Summary
- Port the two neoforge event fixes from the 26.2 branch (`0ccd0b3`, `e4056a7`) to 26.1: `EventInit.init(eventBus)` signature and `onLogin` switched to `FMLLoadCompleteEvent` so `HUDComponent.init()` runs at FML load-complete instead of on player login
- Fix 2 leftover `setScreenAndShow` calls (26.2-only API) in fabric and neoforge `EventInit` that would fail compilation on 26.1 — replaced with `setScreen`

## Test plan
- [x] `./gradlew :common:build :fabric:build :neoforge:build` all pass (JDK 25)
- [x] `./gradlew :neoforge:runClient` — client boots on NeoForge 26.1.2.7-beta, no mixin errors, no crashes